### PR TITLE
helping to have a option if you already have a backend

### DIFF
--- a/libs/terraform/main.sh
+++ b/libs/terraform/main.sh
@@ -21,12 +21,19 @@ checkBins terraform || return ${?}
 # usage: init <terraform path>
 function init() {
 
-    getArgs "terraform_path"
-
+    getArgs "terraform_path bucket= prefix="
+    
     cd "${terraform_path}"
-
-    terraform init
-    exitOnError "Failed to initialize terraform"
+    if [[ ${bucket} ]] && [[ ${prefix} ]]; then
+      # Passing backEnd config on the fly
+      echoInfo "Initializing GCP backEnd from given config."
+      terraform init -backend-config="bucket=${bucket}" -backend-config="prefix=${prefix}"
+      exitOnError "Failed to initialize terraform"
+    else
+      terraform init
+      exitOnError "Failed to initialize terraform"
+    fi
+    
 }
 
 ### Apply terraform plan


### PR DESCRIPTION
The idea here is to give the option to call terraform.init with bucket variables configuration.
It is useful in my case that I do not want to use the terraform.createBucket
And maybe it will be usefull for others providers such as AWS (I did not test)